### PR TITLE
[Feature] #7 - 카카오 로그인 및 JWT 발급 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,6 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	// redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/dorm/lounge/domain/auth/controller/AuthController.java
+++ b/src/main/java/dorm/lounge/domain/auth/controller/AuthController.java
@@ -1,0 +1,30 @@
+package dorm.lounge.domain.auth.controller;
+
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthRequest.SocialLoginRequest;
+import dorm.lounge.domain.auth.service.AuthService;
+import dorm.lounge.global.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "Auth 컨트롤러", description = "카카오 로그인 관련 API")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/kakao/login")
+    @Operation(summary = "카카오 로그인 API", description = "카카오 SDK access token 기반 로그인 API")
+    public ApiResponse<AuthUserResponse> kakaoLogin(@RequestBody SocialLoginRequest request) {
+        return ApiResponse.onSuccess(authService.kakaoLoginWithAccessToken(request.getAccessToken()));
+    }
+
+
+}

--- a/src/main/java/dorm/lounge/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/dorm/lounge/domain/auth/converter/AuthConverter.java
@@ -1,0 +1,18 @@
+package dorm.lounge.domain.auth.converter;
+
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
+import dorm.lounge.domain.user.entity.User;
+
+public class AuthConverter {
+    public static AuthUserResponse toAuthUserResponse(User user, String token) {
+        return AuthUserResponse.builder()
+                .accessToken(token)
+                .gpsVerified(user.getGpsVerified())
+                .gpsVerifiedAt(user.getGpsVerifiedAt())
+                .email(user.getEmail())
+                .name(user.getNickname())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage())
+                .build();
+    }
+}

--- a/src/main/java/dorm/lounge/domain/auth/dto/AuthDTO.java
+++ b/src/main/java/dorm/lounge/domain/auth/dto/AuthDTO.java
@@ -1,0 +1,36 @@
+package dorm.lounge.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class AuthDTO {
+    public static class AuthRequest {
+
+        @Getter
+        @NoArgsConstructor
+        public static class SocialLoginRequest {
+            private String accessToken;
+        }
+    }
+
+    public static class AuthResponse {
+
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
+        public static class AuthUserResponse {
+            private String email;
+            private String name;
+            private String nickname;
+            private String profileImage;
+            private String accessToken;
+            private Boolean gpsVerified;
+            private LocalDateTime gpsVerifiedAt;
+        }
+    }
+}

--- a/src/main/java/dorm/lounge/domain/auth/dto/AuthProfile.java
+++ b/src/main/java/dorm/lounge/domain/auth/dto/AuthProfile.java
@@ -1,0 +1,13 @@
+package dorm.lounge.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+public class AuthProfile {
+    private String email;
+    private String name;
+    private String profileImage;
+}

--- a/src/main/java/dorm/lounge/domain/auth/service/AuthService.java
+++ b/src/main/java/dorm/lounge/domain/auth/service/AuthService.java
@@ -1,0 +1,7 @@
+package dorm.lounge.domain.auth.service;
+
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
+
+public interface AuthService {
+    AuthUserResponse kakaoLoginWithAccessToken(String accessToken);
+}

--- a/src/main/java/dorm/lounge/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/dorm/lounge/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,46 @@
+package dorm.lounge.domain.auth.service;
+
+import dorm.lounge.domain.auth.converter.AuthConverter;
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
+import dorm.lounge.domain.auth.dto.AuthProfile;
+import dorm.lounge.domain.user.entity.User;
+import dorm.lounge.domain.user.repository.UserRepository;
+import dorm.lounge.global.security.JwtProvider;
+import dorm.lounge.global.security.OAuthUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final OAuthUtil oAuthUtil;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+    private final NicknameGenerator nicknameGenerator;
+
+    @Override
+    public AuthUserResponse kakaoLoginWithAccessToken(String accessToken) {
+        // 1. 카카오 사용자 프로필 조회
+        AuthProfile profile = oAuthUtil.getKakaoProfile(accessToken);
+
+        String nickname = nicknameGenerator.generate(); // 랜덤 닉네임
+
+        // 2. 기존 사용자 조회 or 신규 등록
+        User user = userRepository.findByEmail(profile.getEmail()).orElseGet(() ->
+                userRepository.save(User.builder()
+                        .email(profile.getEmail())
+                        .name(profile.getName())
+                        .nickname(nickname)
+                        .profileImage(profile.getProfileImage())
+                        .gpsVerified(false) // 첫 가입자만 false 설정
+                        .build())
+        );
+
+        // 3. JWT 발급
+        String token = jwtProvider.createAccessToken(user.getUserId(), user.getEmail());
+
+        // 4. 응답 DTO 반환
+        return AuthConverter.toAuthUserResponse(user, token);
+    }
+}

--- a/src/main/java/dorm/lounge/domain/auth/service/NicknameGenerator.java
+++ b/src/main/java/dorm/lounge/domain/auth/service/NicknameGenerator.java
@@ -1,0 +1,18 @@
+package dorm.lounge.domain.auth.service;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class NicknameGenerator {
+
+    private static final String[] ADJECTIVES = {"멋진", "귀여운", "똑똑한", "엉뚱한", "용감한"};
+    private static final String[] ANIMALS = {"토끼", "사자", "곰", "너구리", "수달"};
+
+    public String generate() {
+        int adjIdx = (int) (Math.random() * ADJECTIVES.length);
+        int aniIdx = (int) (Math.random() * ANIMALS.length);
+        int number = (int) (Math.random() * 900 + 100); // 100~999
+
+        return ADJECTIVES[adjIdx] + ANIMALS[aniIdx] + "#" + number;
+    }
+}

--- a/src/main/java/dorm/lounge/domain/user/entity/User.java
+++ b/src/main/java/dorm/lounge/domain/user/entity/User.java
@@ -20,9 +20,13 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
+    private String name;
+
     private String nickname;
 
     private String email;
+
+    private String profileImage;
 
     private Boolean gpsVerified;
 

--- a/src/main/java/dorm/lounge/domain/user/repository/UserRepository.java
+++ b/src/main/java/dorm/lounge/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package dorm.lounge.domain.user.repository;
+
+import dorm.lounge.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    public Optional<User> findByEmail(String email);
+}

--- a/src/main/java/dorm/lounge/global/config/SecurityConfig.java
+++ b/src/main/java/dorm/lounge/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package dorm.lounge.global.config;
 
+import dorm.lounge.global.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,12 +8,15 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
@@ -21,6 +25,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 new AntPathRequestMatcher("/"),
+                                new AntPathRequestMatcher("/api/auth/**"),
                                 new AntPathRequestMatcher("/api/v0/auth/**"),
                                 new AntPathRequestMatcher("/swagger-ui.html"),
                                 new AntPathRequestMatcher("/swagger-ui/**"),
@@ -30,7 +35,9 @@ public class SecurityConfig {
                         ).permitAll() // 이 경로들은 모두 인증 없이 접근 가능
                         .anyRequest().authenticated() // 그 외의 모든 경로는 인증 필요
                 )
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
         return httpSecurity.build();
     }
 }

--- a/src/main/java/dorm/lounge/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/dorm/lounge/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package dorm.lounge.global.security;
+
+import dorm.lounge.domain.user.entity.User;
+import dorm.lounge.domain.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String token = jwtUtil.extractToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Claims claims = jwtProvider.parseClaims(token);
+            Long userId = jwtUtil.extractUserId(claims);
+
+            User user = userRepository.findById(userId).orElseThrow();
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(user, null, List.of());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/dorm/lounge/global/security/JwtProvider.java
+++ b/src/main/java/dorm/lounge/global/security/JwtProvider.java
@@ -1,0 +1,44 @@
+package dorm.lounge.global.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    private static final long ACCESS_TOKEN_VALID_TIME = 60 * 60 * 1000L; // 1시간
+
+    public String createAccessToken(Long userId, String email) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim("email", email)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_VALID_TIME))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+    }
+}

--- a/src/main/java/dorm/lounge/global/security/JwtUtil.java
+++ b/src/main/java/dorm/lounge/global/security/JwtUtil.java
@@ -1,0 +1,32 @@
+package dorm.lounge.global.security;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    // 헤더에서 JWT 추출
+    public String extractToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    // claim에서 userId 꺼내기
+    public Long extractUserId(Claims claims) {
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public String extractEmail(Claims claims) {
+        return claims.get("email", String.class);
+    }
+}

--- a/src/main/java/dorm/lounge/global/security/OAuthConstants.java
+++ b/src/main/java/dorm/lounge/global/security/OAuthConstants.java
@@ -1,0 +1,13 @@
+package dorm.lounge.global.security;
+
+public class OAuthConstants {
+
+    // Token 요청 URL
+    public static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    // Profile 요청 URL
+    public static final String KAKAO_PROFILE_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private OAuthConstants() {
+        // 상수 클래스는 인스턴스화 금지
+    }
+}

--- a/src/main/java/dorm/lounge/global/security/OAuthUtil.java
+++ b/src/main/java/dorm/lounge/global/security/OAuthUtil.java
@@ -1,0 +1,47 @@
+package dorm.lounge.global.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dorm.lounge.domain.auth.dto.AuthProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthUtil {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper;
+
+    public AuthProfile getKakaoProfile(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                OAuthConstants.KAKAO_PROFILE_URL,
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+
+        try {
+            JsonNode json = objectMapper.readTree(response.getBody());
+            JsonNode account = json.get("kakao_account");
+            JsonNode profile = account.get("profile");
+
+            return AuthProfile.builder()
+                    .email(account.get("email").asText())
+                    .name(profile.get("nickname").asText())
+                    .profileImage(profile.get("profile_image_url").asText())
+                    .build();
+
+        } catch (Exception e) {
+            throw new RuntimeException("카카오 프로필 파싱 실패");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,7 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+
+
+  jwt:
+    secret: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## Related Issue 🍀
- #7 

<br>

## Key Changes 🔑
- accessToken 기반 사용자 프로필 요청 (OAuthUtil.getKakaoProfile)
- 사용자 정보 파싱 후, 신규 유저일 경우 DB에 저장 (UserRepository)
- 닉네임은 랜덤 생성기(NicknameGenerator)를 통해 자동 생성
- JwtProvider를 통해 로그인 성공 시 AccessToken 생성
- 사용자 식별자(userId)와 email을 포함한 JWT 생성
- AuthUserResponse에 사용자 정보 + AccessToken 포함하여 반환
- Spring Security + JWT 필터 적용
- JwtAuthenticationFilter 구현하여 토큰 기반 인증 적용
- 유효한 토큰인 경우, 해당 유저 정보로 SecurityContext 설정

<br>

## To Reviewers 🙏🏻
- 실행 화면
<img width="1284" alt="스크린샷 2025-04-17 오전 10 00 54" src="https://github.com/user-attachments/assets/0ea24f43-0ad6-4c6c-86b2-9c33f7e3a4c4" />
