### PR TITLE
[Feature] #9 - GPS 인증 기능 구현 및 로그인 기능 개선

### DIFF
--- a/src/main/java/dorm/lounge/domain/auth/controller/AuthController.java
+++ b/src/main/java/dorm/lounge/domain/auth/controller/AuthController.java
@@ -1,13 +1,13 @@
 package dorm.lounge.domain.auth.controller;
 
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthRequest.TokenRefreshRequest;
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.TokenRefreshResponse;
 import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
 import dorm.lounge.domain.auth.dto.AuthDTO.AuthRequest.SocialLoginRequest;
 import dorm.lounge.domain.auth.service.AuthService;
 import dorm.lounge.global.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +25,12 @@ public class AuthController {
     @PostMapping("/kakao/login")
     @Operation(summary = "카카오 로그인 API", description = "카카오 access token 기반 로그인 API")
     public ApiResponse<AuthUserResponse> kakaoLogin(@RequestBody SocialLoginRequest request) {
-        return ApiResponse.onSuccess(authService.kakaoLoginWithAccessToken(request.getAccessToken()));
+        return ApiResponse.onSuccess(authService.kakaoLoginWithAccessToken(request));
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "AccessToken 재발급", description = "RefreshToken을 통해 새로운 AccessToken을 재발급")
+    public ApiResponse<TokenRefreshResponse> refreshAccessToken(@RequestBody TokenRefreshRequest request) {
+        return ApiResponse.onSuccess(authService.refreshAccessToken(request));
     }
 }

--- a/src/main/java/dorm/lounge/domain/auth/controller/AuthController.java
+++ b/src/main/java/dorm/lounge/domain/auth/controller/AuthController.java
@@ -6,6 +6,8 @@ import dorm.lounge.domain.auth.service.AuthService;
 import dorm.lounge.global.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,10 +23,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/kakao/login")
-    @Operation(summary = "카카오 로그인 API", description = "카카오 SDK access token 기반 로그인 API")
+    @Operation(summary = "카카오 로그인 API", description = "카카오 access token 기반 로그인 API")
     public ApiResponse<AuthUserResponse> kakaoLogin(@RequestBody SocialLoginRequest request) {
         return ApiResponse.onSuccess(authService.kakaoLoginWithAccessToken(request.getAccessToken()));
     }
-
-
 }

--- a/src/main/java/dorm/lounge/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/dorm/lounge/domain/auth/converter/AuthConverter.java
@@ -1,5 +1,6 @@
 package dorm.lounge.domain.auth.converter;
 
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.TokenRefreshResponse;
 import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
 import dorm.lounge.domain.user.entity.User;
 
@@ -15,6 +16,13 @@ public class AuthConverter {
                 .nickname(user.getNickname())
                 .profileImage(user.getProfileImage())
                 .requireGps(requireGps)
+                .build();
+    }
+
+    public static TokenRefreshResponse toTokenRefreshResponse(String newAccessToken, String newRefreshToken) {
+        return TokenRefreshResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
                 .build();
     }
 }

--- a/src/main/java/dorm/lounge/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/dorm/lounge/domain/auth/converter/AuthConverter.java
@@ -4,7 +4,7 @@ import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
 import dorm.lounge.domain.user.entity.User;
 
 public class AuthConverter {
-    public static AuthUserResponse toAuthUserResponse(User user, String token) {
+    public static AuthUserResponse toAuthUserResponse(Boolean requireGps, User user, String token) {
         return AuthUserResponse.builder()
                 .accessToken(token)
                 .gpsVerified(user.getGpsVerified())
@@ -13,6 +13,7 @@ public class AuthConverter {
                 .name(user.getNickname())
                 .nickname(user.getNickname())
                 .profileImage(user.getProfileImage())
+                .requireGps(requireGps)
                 .build();
     }
 }

--- a/src/main/java/dorm/lounge/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/dorm/lounge/domain/auth/converter/AuthConverter.java
@@ -4,9 +4,10 @@ import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
 import dorm.lounge.domain.user.entity.User;
 
 public class AuthConverter {
-    public static AuthUserResponse toAuthUserResponse(Boolean requireGps, User user, String token) {
+    public static AuthUserResponse toAuthUserResponse(Boolean requireGps, User user, String accessToken, String refreshToken) {
         return AuthUserResponse.builder()
-                .accessToken(token)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .gpsVerified(user.getGpsVerified())
                 .gpsVerifiedAt(user.getGpsVerifiedAt())
                 .email(user.getEmail())

--- a/src/main/java/dorm/lounge/domain/auth/dto/AuthDTO.java
+++ b/src/main/java/dorm/lounge/domain/auth/dto/AuthDTO.java
@@ -31,6 +31,7 @@ public class AuthDTO {
             private String accessToken;
             private Boolean gpsVerified;
             private LocalDateTime gpsVerifiedAt;
+            private Boolean requireGps; // GPS 인증 필요 여부
         }
     }
 }

--- a/src/main/java/dorm/lounge/domain/auth/dto/AuthDTO.java
+++ b/src/main/java/dorm/lounge/domain/auth/dto/AuthDTO.java
@@ -15,6 +15,12 @@ public class AuthDTO {
         public static class SocialLoginRequest {
             private String accessToken;
         }
+
+        @Getter
+        @NoArgsConstructor
+        public static class TokenRefreshRequest {
+            private String refreshToken;
+        }
     }
 
     public static class AuthResponse {
@@ -33,6 +39,14 @@ public class AuthDTO {
             private Boolean gpsVerified;
             private LocalDateTime gpsVerifiedAt;
             private Boolean requireGps; // GPS 인증 필요 여부
+        }
+
+        @Getter
+        @AllArgsConstructor
+        @Builder
+        public static class TokenRefreshResponse {
+            private String accessToken;
+            private String refreshToken;
         }
     }
 }

--- a/src/main/java/dorm/lounge/domain/auth/dto/AuthDTO.java
+++ b/src/main/java/dorm/lounge/domain/auth/dto/AuthDTO.java
@@ -29,6 +29,7 @@ public class AuthDTO {
             private String nickname;
             private String profileImage;
             private String accessToken;
+            private String refreshToken;
             private Boolean gpsVerified;
             private LocalDateTime gpsVerifiedAt;
             private Boolean requireGps; // GPS 인증 필요 여부

--- a/src/main/java/dorm/lounge/domain/auth/service/AuthService.java
+++ b/src/main/java/dorm/lounge/domain/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package dorm.lounge.domain.auth.service;
 
 import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
     AuthUserResponse kakaoLoginWithAccessToken(String accessToken);

--- a/src/main/java/dorm/lounge/domain/auth/service/AuthService.java
+++ b/src/main/java/dorm/lounge/domain/auth/service/AuthService.java
@@ -1,9 +1,12 @@
 package dorm.lounge.domain.auth.service;
 
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthRequest.SocialLoginRequest;
 import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthRequest.TokenRefreshRequest;
+import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.TokenRefreshResponse;
 
 public interface AuthService {
-    AuthUserResponse kakaoLoginWithAccessToken(String accessToken);
+    AuthUserResponse kakaoLoginWithAccessToken(SocialLoginRequest socialLoginRequest);
+    TokenRefreshResponse refreshAccessToken(TokenRefreshRequest tokenRefreshRequest);
 }

--- a/src/main/java/dorm/lounge/domain/user/controller/UserController.java
+++ b/src/main/java/dorm/lounge/domain/user/controller/UserController.java
@@ -1,0 +1,2 @@
+package dorm.lounge.domain.user.controller;public class UserController {
+}

--- a/src/main/java/dorm/lounge/domain/user/controller/UserController.java
+++ b/src/main/java/dorm/lounge/domain/user/controller/UserController.java
@@ -1,2 +1,30 @@
-package dorm.lounge.domain.user.controller;public class UserController {
+package dorm.lounge.domain.user.controller;
+
+import dorm.lounge.domain.user.dto.UserDTO.UserResponse.GpsResponse;
+import dorm.lounge.domain.user.dto.UserDTO.UserRequest.GpsRequest;
+import dorm.lounge.domain.user.service.UserService;
+import dorm.lounge.global.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+@Tag(name = "User 컨트롤러", description = "User 관련 API")
+public class UserController {
+
+    private final UserService userService;
+    @PostMapping("/gps")
+    @Operation(summary = "GPS 인증 처리", description = "클라이언트 측 인증 결과에 따라 인증 상태 저장")
+    public ApiResponse<GpsResponse> verifyGps(Authentication authentication, @RequestBody GpsRequest request) {
+        GpsResponse response = userService.verifyGps(authentication.getName(), request);
+        return ApiResponse.onSuccess(response);
+    }
+
 }

--- a/src/main/java/dorm/lounge/domain/user/controller/UserController.java
+++ b/src/main/java/dorm/lounge/domain/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package dorm.lounge.domain.user.controller;
 
-import dorm.lounge.domain.user.dto.UserDTO.UserResponse.GpsResponse;
 import dorm.lounge.domain.user.dto.UserDTO.UserRequest.GpsRequest;
 import dorm.lounge.domain.user.service.UserService;
 import dorm.lounge.global.ApiResponse;
@@ -22,9 +21,9 @@ public class UserController {
     private final UserService userService;
     @PostMapping("/gps")
     @Operation(summary = "GPS 인증 처리", description = "클라이언트 측 인증 결과에 따라 인증 상태 저장")
-    public ApiResponse<GpsResponse> verifyGps(Authentication authentication, @RequestBody GpsRequest request) {
-        GpsResponse response = userService.verifyGps(authentication.getName(), request);
-        return ApiResponse.onSuccess(response);
+    public ApiResponse<String> verifyGps(Authentication authentication, @RequestBody GpsRequest request) {
+        userService.verifyGps(authentication.getName(), request);
+        return ApiResponse.onSuccess("인증 성공");
     }
 
 }

--- a/src/main/java/dorm/lounge/domain/user/converter/UserConverter.java
+++ b/src/main/java/dorm/lounge/domain/user/converter/UserConverter.java
@@ -1,2 +1,4 @@
-package dorm.lounge.domain.user.converter;public class UserConverter {
+package dorm.lounge.domain.user.converter;
+
+public class UserConverter {
 }

--- a/src/main/java/dorm/lounge/domain/user/converter/UserConverter.java
+++ b/src/main/java/dorm/lounge/domain/user/converter/UserConverter.java
@@ -1,0 +1,2 @@
+package dorm.lounge.domain.user.converter;public class UserConverter {
+}

--- a/src/main/java/dorm/lounge/domain/user/dto/UserDTO.java
+++ b/src/main/java/dorm/lounge/domain/user/dto/UserDTO.java
@@ -14,10 +14,6 @@ public class UserDTO {
     }
 
     public static class UserResponse {
-        @Getter
-        @AllArgsConstructor
-        public static class GpsResponse {
-            private boolean success;
-        }
+
     }
 }

--- a/src/main/java/dorm/lounge/domain/user/dto/UserDTO.java
+++ b/src/main/java/dorm/lounge/domain/user/dto/UserDTO.java
@@ -1,0 +1,2 @@
+package dorm.lounge.domain.user.dto;public class UserDTO {
+}

--- a/src/main/java/dorm/lounge/domain/user/dto/UserDTO.java
+++ b/src/main/java/dorm/lounge/domain/user/dto/UserDTO.java
@@ -1,2 +1,23 @@
-package dorm.lounge.domain.user.dto;public class UserDTO {
+package dorm.lounge.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserDTO {
+    public static class UserRequest {
+        @Getter
+        @NoArgsConstructor
+        public static class GpsRequest {
+            private boolean success; // 클라이언트에서 GPS 인증 성공 여부
+        }
+    }
+
+    public static class UserResponse {
+        @Getter
+        @AllArgsConstructor
+        public static class GpsResponse {
+            private boolean success;
+        }
+    }
 }

--- a/src/main/java/dorm/lounge/domain/user/entity/Building.java
+++ b/src/main/java/dorm/lounge/domain/user/entity/Building.java
@@ -1,5 +1,0 @@
-package dorm.lounge.domain.user.entity;
-
-public enum Building {
-    창의관, 지혜관
-}

--- a/src/main/java/dorm/lounge/domain/user/entity/User.java
+++ b/src/main/java/dorm/lounge/domain/user/entity/User.java
@@ -32,10 +32,12 @@ public class User {
 
     private LocalDateTime gpsVerifiedAt;
 
-    @Enumerated(EnumType.STRING)
-    private Building building;
+    @Column(length = 500)
+    private String refreshToken;
 
-    private String roomNumber;
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 
     public void updateGps(LocalDateTime verifiedAt) {
         this.gpsVerified = true;

--- a/src/main/java/dorm/lounge/domain/user/entity/User.java
+++ b/src/main/java/dorm/lounge/domain/user/entity/User.java
@@ -36,4 +36,14 @@ public class User {
     private Building building;
 
     private String roomNumber;
+
+    public void updateGps(LocalDateTime verifiedAt) {
+        this.gpsVerified = true;
+        this.gpsVerifiedAt = verifiedAt;
+    }
+
+    public void clearGps() {
+        this.gpsVerified = false;
+        this.gpsVerifiedAt = null;
+    }
 }

--- a/src/main/java/dorm/lounge/domain/user/service/UserService.java
+++ b/src/main/java/dorm/lounge/domain/user/service/UserService.java
@@ -1,8 +1,7 @@
 package dorm.lounge.domain.user.service;
 
 import dorm.lounge.domain.user.dto.UserDTO.UserRequest.GpsRequest;
-import dorm.lounge.domain.user.dto.UserDTO.UserResponse.GpsResponse;
 
 public interface UserService {
-    GpsResponse verifyGps(String userId, GpsRequest request);
+    void verifyGps(String userId, GpsRequest request);
 }

--- a/src/main/java/dorm/lounge/domain/user/service/UserService.java
+++ b/src/main/java/dorm/lounge/domain/user/service/UserService.java
@@ -1,2 +1,8 @@
-package dorm.lounge.domain.user.service;public interface UserService {
+package dorm.lounge.domain.user.service;
+
+import dorm.lounge.domain.user.dto.UserDTO.UserRequest.GpsRequest;
+import dorm.lounge.domain.user.dto.UserDTO.UserResponse.GpsResponse;
+
+public interface UserService {
+    GpsResponse verifyGps(String userId, GpsRequest request);
 }

--- a/src/main/java/dorm/lounge/domain/user/service/UserService.java
+++ b/src/main/java/dorm/lounge/domain/user/service/UserService.java
@@ -1,0 +1,2 @@
+package dorm.lounge.domain.user.service;public interface UserService {
+}

--- a/src/main/java/dorm/lounge/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/dorm/lounge/domain/user/service/UserServiceImpl.java
@@ -1,7 +1,6 @@
 package dorm.lounge.domain.user.service;
 
 import dorm.lounge.domain.user.dto.UserDTO.UserRequest.GpsRequest;
-import dorm.lounge.domain.user.dto.UserDTO.UserResponse.GpsResponse;
 import dorm.lounge.domain.user.entity.User;
 import dorm.lounge.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,14 +17,12 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public GpsResponse verifyGps(String userId, GpsRequest request) {
+    public void verifyGps(String userId, GpsRequest request) {
         User user = userRepository.findById(Long.valueOf(userId))
                 .orElseThrow(() -> new RuntimeException("사용자 없음"));
 
         if (request.isSuccess()) {
             user.updateGps(LocalDateTime.now());
         }
-
-        return new GpsResponse(request.isSuccess());
     }
 }

--- a/src/main/java/dorm/lounge/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/dorm/lounge/domain/user/service/UserServiceImpl.java
@@ -1,2 +1,31 @@
-package dorm.lounge.domain.user.service;public class UserServiceImpl {
+package dorm.lounge.domain.user.service;
+
+import dorm.lounge.domain.user.dto.UserDTO.UserRequest.GpsRequest;
+import dorm.lounge.domain.user.dto.UserDTO.UserResponse.GpsResponse;
+import dorm.lounge.domain.user.entity.User;
+import dorm.lounge.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public GpsResponse verifyGps(String userId, GpsRequest request) {
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new RuntimeException("사용자 없음"));
+
+        if (request.isSuccess()) {
+            user.updateGps(LocalDateTime.now());
+        }
+
+        return new GpsResponse(request.isSuccess());
+    }
 }

--- a/src/main/java/dorm/lounge/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/dorm/lounge/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,2 @@
+package dorm.lounge.domain.user.service;public class UserServiceImpl {
+}

--- a/src/main/java/dorm/lounge/global/security/CustomUserDetails.java
+++ b/src/main/java/dorm/lounge/global/security/CustomUserDetails.java
@@ -1,0 +1,2 @@
+package dorm.lounge.global.security;public class CustomUserDetails {
+}

--- a/src/main/java/dorm/lounge/global/security/CustomUserDetails.java
+++ b/src/main/java/dorm/lounge/global/security/CustomUserDetails.java
@@ -1,2 +1,46 @@
-package dorm.lounge.global.security;public class CustomUserDetails {
+package dorm.lounge.global.security;
+
+import dorm.lounge.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList(); // 권한 미사용 시
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // 비밀번호 로그인 X
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(user.getUserId()); // getName() = userId
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
 }

--- a/src/main/java/dorm/lounge/global/security/CustomUserDetailsService.java
+++ b/src/main/java/dorm/lounge/global/security/CustomUserDetailsService.java
@@ -1,0 +1,2 @@
+package dorm.lounge.global.security;public class CustomUserDetailsService {
+}

--- a/src/main/java/dorm/lounge/global/security/CustomUserDetailsService.java
+++ b/src/main/java/dorm/lounge/global/security/CustomUserDetailsService.java
@@ -1,2 +1,23 @@
-package dorm.lounge.global.security;public class CustomUserDetailsService {
+package dorm.lounge.global.security;
+
+import dorm.lounge.domain.user.entity.User;
+import dorm.lounge.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        return userRepository.findById(Long.parseLong(userId))
+                .map(CustomUserDetails::new)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자 없음"));
+    }
 }

--- a/src/main/java/dorm/lounge/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/dorm/lounge/global/security/JwtAuthenticationFilter.java
@@ -1,7 +1,5 @@
 package dorm.lounge.global.security;
 
-import dorm.lounge.domain.user.entity.User;
-import dorm.lounge.domain.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -21,7 +19,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtProvider jwtProvider;
     private final JwtUtil jwtUtil;
     private final CustomUserDetailsService customUserDetailsService;
 
@@ -32,8 +29,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = jwtUtil.extractToken(request);
 
-        if (token != null && jwtProvider.validateToken(token)) {
-            Claims claims = jwtProvider.parseClaims(token);
+        if (token != null && jwtUtil.validateToken(token)) {
+            Claims claims = jwtUtil.parseClaims(token);
             Long userId = jwtUtil.extractUserId(claims);
 
             UserDetails userDetails = customUserDetailsService.loadUserByUsername(String.valueOf(userId));

--- a/src/main/java/dorm/lounge/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/dorm/lounge/global/security/JwtAuthenticationFilter.java
@@ -35,10 +35,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Claims claims = jwtProvider.parseClaims(token);
             Long userId = jwtUtil.extractUserId(claims);
 
-            User user = userRepository.findById(userId).orElseThrow();
-
             UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(user, null, List.of());
+                    new UsernamePasswordAuthenticationToken(String.valueOf(userId), null, List.of());
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/dorm/lounge/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/dorm/lounge/global/security/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -22,7 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final JwtUtil jwtUtil;
-    private final UserRepository userRepository;
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -35,8 +36,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Claims claims = jwtProvider.parseClaims(token);
             Long userId = jwtUtil.extractUserId(claims);
 
+            UserDetails userDetails = customUserDetailsService.loadUserByUsername(String.valueOf(userId));
+
             UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(String.valueOf(userId), null, List.of());
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/dorm/lounge/global/security/JwtProvider.java
+++ b/src/main/java/dorm/lounge/global/security/JwtProvider.java
@@ -1,12 +1,16 @@
 package dorm.lounge.global.security;
 
-import io.jsonwebtoken.Claims;
+import dorm.lounge.domain.user.entity.User;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 @Component
@@ -14,31 +18,32 @@ import java.util.Date;
 public class JwtProvider {
 
     @Value("${spring.jwt.secret}")
-    private String secretKey;
+    private String secretKeyString;
 
     private static final long ACCESS_TOKEN_VALID_TIME = 60 * 60 * 1000L; // 1시간
+    private static final long REFRESH_TOKEN_VALID_TIME = 604800000; // 7일
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
+    }
 
     public String createAccessToken(Long userId, String email) {
-        Date now = new Date();
+        return createToken(userId, email, ACCESS_TOKEN_VALID_TIME);
+    }
+
+    public String createRefreshToken(Long userId, String email)  {
+        return createToken(userId, email, REFRESH_TOKEN_VALID_TIME);
+    }
+
+    private String createToken(Long userId, String email, long expirationMs) {
         return Jwts.builder()
-                .setSubject(String.valueOf(userId))
-                .claim("email", email)
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_VALID_TIME))
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .setSubject(String.valueOf(userId)) // userId를 Subject로 저장
+                .claim("email", email) // email을 claims로 저장
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(secretKey, SignatureAlgorithm.HS512)
                 .compact();
-    }
-
-    public boolean validateToken(String token) {
-        try {
-            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    public Claims parseClaims(String token) {
-        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
     }
 }

--- a/src/main/java/dorm/lounge/global/security/JwtUtil.java
+++ b/src/main/java/dorm/lounge/global/security/JwtUtil.java
@@ -1,16 +1,33 @@
 package dorm.lounge.global.security;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
 public class JwtUtil {
 
+    @Value("${spring.jwt.secret}")
+    private String secretKeyString;
+
     private static final String BEARER_PREFIX = "Bearer ";
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
+    }
 
     // 헤더에서 JWT 추출
     public String extractToken(HttpServletRequest request) {
@@ -28,5 +45,18 @@ public class JwtUtil {
 
     public String extractEmail(Claims claims) {
         return claims.get("email", String.class);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
     }
 }


### PR DESCRIPTION
## Related Issue 🍀
- #9 

<br>

## Key Changes 🔑
- Spring Security 기반 인증 구조를 UserDetails 기반 구조로 개선
- CustomUserDetails, CustomUserDetailsService, JwtAuthenticationFilter 적용
- 카카오 로그인 시 AccessToken + RefreshToken 발급
- RefreshToken은 User 엔티티에 저장하여 이후 재발급 처리 가능하게 구조 마련
- /api/user/gps API를 통해 클라이언트 측 인증 성공 여부(success)를 서버에 전달
- 인증 성공 시 gpsVerified, gpsVerifiedAt 컬럼 업데이트
- 로그인 시 GPS 인증 만료(3개월 경과) 여부 판단 및 초기화 처리
- 응답 DTO에 requireGps 필드 추가하여 클라이언트에게 인증 필요 여부 명시
- RefreshToken 재발급 API 구현
- 유효한 refreshToken으로 accessToken + refreshToken 동시 갱신 (DB의 refreshToken 값도 갱신)

<br>

## To Reviewers 🙏🏻
- 로그인 시 GPS 인증 여부 반환
<img width="1284" alt="require GPS" src="https://github.com/user-attachments/assets/ae1cf54a-2dcf-4ecd-b944-b2ca2b98ea7e" />

- GPS 인증
<img width="1284" alt="GPS 인증" src="https://github.com/user-attachments/assets/fbfa7bdb-656e-45a8-a56a-26aa22933736" />

- refreshToken 갱신
<img width="1284" alt="refresh 갱신" src="https://github.com/user-attachments/assets/81684670-ee63-46af-bd65-8ee30cd5ebcb" />
