### PR TITLE
[Feature] #19 - 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/dorm/lounge/domain/auth/controller/AuthController.java
+++ b/src/main/java/dorm/lounge/domain/auth/controller/AuthController.java
@@ -9,10 +9,8 @@ import dorm.lounge.global.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,4 +31,12 @@ public class AuthController {
     public ApiResponse<TokenRefreshResponse> refreshAccessToken(@RequestBody TokenRefreshRequest request) {
         return ApiResponse.onSuccess(authService.refreshAccessToken(request));
     }
+
+    @DeleteMapping("/logout")
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자가 회원 탈퇴를 수행합니다.")
+    public ApiResponse<String> withdraw(Authentication authentication) {
+        authService.withdraw(authentication.getName());
+        return ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다.");
+    }
+
 }

--- a/src/main/java/dorm/lounge/domain/auth/service/AuthService.java
+++ b/src/main/java/dorm/lounge/domain/auth/service/AuthService.java
@@ -9,4 +9,5 @@ import dorm.lounge.domain.auth.dto.AuthDTO.AuthResponse.TokenRefreshResponse;
 public interface AuthService {
     AuthUserResponse kakaoLoginWithAccessToken(SocialLoginRequest socialLoginRequest);
     TokenRefreshResponse refreshAccessToken(TokenRefreshRequest tokenRefreshRequest);
+    void withdraw(String userId);
 }

--- a/src/main/java/dorm/lounge/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/dorm/lounge/domain/auth/service/AuthServiceImpl.java
@@ -107,4 +107,13 @@ public class AuthServiceImpl implements AuthService {
         return AuthConverter.toTokenRefreshResponse(newAccessToken, newRefreshToken);
 
     }
+
+    @Override
+    @Transactional
+    public void withdraw(String userId) {
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        userRepository.delete(user); // 하드 삭제 방식
+    }
 }


### PR DESCRIPTION
## Related Issue 🍀
- #19 

<br>

## Key Changes 🔑
- 회원 탈퇴 API 구현 : /api/auth/logout
- 사용자 DB에서 하드 삭제 방식으로 처리

<br>

## To Reviewers 🙏🏻
- 