### PR TITLE
[Feature] #21 - 댓글 등록 및 삭제 API 구현 + 본인 작성 여부 반환

### DIFF
--- a/src/main/java/dorm/lounge/domain/post/controller/CommentController.java
+++ b/src/main/java/dorm/lounge/domain/post/controller/CommentController.java
@@ -2,6 +2,7 @@ package dorm.lounge.domain.post.controller;
 
 import dorm.lounge.domain.post.dto.CommentDTO.CommentRequest.CreateCommentRequest;
 import dorm.lounge.domain.post.dto.CommentDTO.CommentResponse.CreateCommentResponse;
+import dorm.lounge.domain.post.service.CommentLikeService;
 import dorm.lounge.domain.post.service.CommentService;
 import dorm.lounge.global.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
 
     private final CommentService commentService;
+    private final CommentLikeService commentLikeService;
 
     @PostMapping("/{postId}/comments")
     @Operation(summary = "댓글 등록", description = "게시글에 댓글을 등록합니다.")
@@ -38,5 +40,19 @@ public class CommentController {
     ) {
         commentService.deleteComment(authentication.getName(), commentId);
         return ApiResponse.onSuccess("댓글 삭제 완료");
+    }
+
+    @PostMapping("/{commentId}/like")
+    @Operation(summary = "댓글 좋아요 등록", description = "댓글에 좋아요를 누릅니다.")
+    public ApiResponse<String> like(@PathVariable Long commentId, Authentication authentication) {
+        commentLikeService.likeComment(authentication.getName(), commentId);
+        return ApiResponse.onSuccess("좋아요 완료");
+    }
+
+    @DeleteMapping("/{commentId}/like")
+    @Operation(summary = "댓글 좋아요 취소", description = "댓글 좋아요를 취소합니다.")
+    public ApiResponse<String> unlike(@PathVariable Long commentId, Authentication authentication) {
+        commentLikeService.unlikeComment(authentication.getName(), commentId);
+        return ApiResponse.onSuccess("좋아요 취소 완료");
     }
 }

--- a/src/main/java/dorm/lounge/domain/post/converter/PostConverter.java
+++ b/src/main/java/dorm/lounge/domain/post/converter/PostConverter.java
@@ -66,11 +66,13 @@ public class PostConverter {
                 .build();
     }
 
-    public static GetComment toComment(Comment comment) {
+    public static GetComment toComment(Comment comment, boolean isLiked, int likeCount) {
         return GetComment.builder()
                 .commentId(comment.getCommentId())
                 .content(comment.getContent())
                 .createdAt(formatTime(comment.getCreatedAt()))
+                .isLiked(isLiked)
+                .likeCount(likeCount)
                 .build();
     }
 

--- a/src/main/java/dorm/lounge/domain/post/converter/PostConverter.java
+++ b/src/main/java/dorm/lounge/domain/post/converter/PostConverter.java
@@ -37,7 +37,7 @@ public class PostConverter {
                 .build();
     }
 
-    public static GetPostResponse toPostList(Post post, boolean isLiked) {
+    public static GetPostResponse toPostList(Post post, boolean isLiked, boolean isMine) {
         return GetPostResponse.builder()
                 .postId(post.getPostId())
                 .title(post.getTitle())
@@ -47,11 +47,12 @@ public class PostConverter {
                 .viewCount(post.getViewCount())
                 .createdAt(formatTime(post.getCreatedAt()))
                 .isLiked(isLiked)
+                .isMine(isMine)
                 .commentCount(post.getComments().size())
                 .build();
     }
 
-    public static GetPostResponse toPostDetail(Post post, boolean isLiked, List<GetComment> comments) {
+    public static GetPostResponse toPostDetail(Post post, boolean isLiked, List<GetComment> comments, boolean isMine) {
         return GetPostResponse.builder()
                 .postId(post.getPostId())
                 .title(post.getTitle())
@@ -61,17 +62,18 @@ public class PostConverter {
                 .viewCount(post.getViewCount())
                 .createdAt(formatTime(post.getCreatedAt()))
                 .isLiked(isLiked)
+                .isMine(isMine)
                 .comments(comments)
                 .commentCount(post.getComments().size())
                 .build();
     }
 
-    public static GetComment toComment(Comment comment, boolean isLiked, int likeCount) {
+    public static GetComment toComment(Comment comment, boolean isMine, int likeCount) {
         return GetComment.builder()
                 .commentId(comment.getCommentId())
                 .content(comment.getContent())
                 .createdAt(formatTime(comment.getCreatedAt()))
-                .isLiked(isLiked)
+                .isMine(isMine)
                 .likeCount(likeCount)
                 .build();
     }

--- a/src/main/java/dorm/lounge/domain/post/dto/PostDTO.java
+++ b/src/main/java/dorm/lounge/domain/post/dto/PostDTO.java
@@ -54,6 +54,8 @@ public class PostDTO {
             private Long commentId;
             private String content;
             private String createdAt;
+            private int likeCount;
+            private boolean isLiked;
         }
 
         @Getter

--- a/src/main/java/dorm/lounge/domain/post/dto/PostDTO.java
+++ b/src/main/java/dorm/lounge/domain/post/dto/PostDTO.java
@@ -44,6 +44,7 @@ public class PostDTO {
             private int viewCount;
             private String createdAt;
             private boolean isLiked;
+            private boolean isMine;
             private int commentCount;
             private List<GetComment> comments;
         }
@@ -55,7 +56,7 @@ public class PostDTO {
             private String content;
             private String createdAt;
             private int likeCount;
-            private boolean isLiked;
+            private boolean isMine;
         }
 
         @Getter

--- a/src/main/java/dorm/lounge/domain/post/entity/Comment.java
+++ b/src/main/java/dorm/lounge/domain/post/entity/Comment.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -30,4 +33,7 @@ public class Comment extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CommentLike> commentLikes = new ArrayList<>();
 }

--- a/src/main/java/dorm/lounge/domain/post/entity/CommentLike.java
+++ b/src/main/java/dorm/lounge/domain/post/entity/CommentLike.java
@@ -1,0 +1,30 @@
+package dorm.lounge.domain.post.entity;
+
+import dorm.lounge.domain.user.entity.User;
+import dorm.lounge.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "commentLike")
+public class CommentLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "commentId")
+    private Comment comment;
+}

--- a/src/main/java/dorm/lounge/domain/post/entity/Post.java
+++ b/src/main/java/dorm/lounge/domain/post/entity/Post.java
@@ -39,6 +39,9 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostLike> postLikes = new ArrayList<>();
+
     public void update(String title, String content) {
         this.title = title;
         this.content = content;

--- a/src/main/java/dorm/lounge/domain/post/repository/CommentLikeRepository.java
+++ b/src/main/java/dorm/lounge/domain/post/repository/CommentLikeRepository.java
@@ -1,0 +1,12 @@
+package dorm.lounge.domain.post.repository;
+
+import dorm.lounge.domain.post.entity.Comment;
+import dorm.lounge.domain.post.entity.CommentLike;
+import dorm.lounge.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    boolean existsByUserAndComment(User user, Comment comment);
+    void deleteByUserAndComment(User user, Comment comment);
+    long countByComment(Comment comment);
+}

--- a/src/main/java/dorm/lounge/domain/post/service/CommentLikeService.java
+++ b/src/main/java/dorm/lounge/domain/post/service/CommentLikeService.java
@@ -1,0 +1,6 @@
+package dorm.lounge.domain.post.service;
+
+public interface CommentLikeService {
+    void likeComment(String userId, Long commentId);
+    void unlikeComment(String userId, Long commentId);
+}

--- a/src/main/java/dorm/lounge/domain/post/service/CommentLikeServiceImpl.java
+++ b/src/main/java/dorm/lounge/domain/post/service/CommentLikeServiceImpl.java
@@ -1,0 +1,45 @@
+package dorm.lounge.domain.post.service;
+
+import dorm.lounge.domain.post.entity.Comment;
+import dorm.lounge.domain.post.entity.CommentLike;
+import dorm.lounge.domain.post.repository.CommentLikeRepository;
+import dorm.lounge.domain.post.repository.CommentRepository;
+import dorm.lounge.domain.user.entity.User;
+import dorm.lounge.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentLikeServiceImpl implements CommentLikeService {
+
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+
+    @Override
+    @Transactional
+    public void likeComment(String userId, Long commentId) {
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new RuntimeException("사용자 없음"));
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("댓글 없음"));
+
+        if (!commentLikeRepository.existsByUserAndComment(user, comment)) {
+            CommentLike like = CommentLike.builder().user(user).comment(comment).build();
+            commentLikeRepository.save(like);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void unlikeComment(String userId, Long commentId) {
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new RuntimeException("사용자 없음"));
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("댓글 없음"));
+
+        commentLikeRepository.deleteByUserAndComment(user, comment);
+    }
+}

--- a/src/main/java/dorm/lounge/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/dorm/lounge/domain/post/service/PostServiceImpl.java
@@ -105,11 +105,19 @@ public class PostServiceImpl implements PostService {
         List<Post> bestPosts = postRepository.findTop3ByCreatedAtAfterOrderByLikeCountDesc(sevenDaysAgo);
 
         List<GetPostResponse> postList = posts.stream()
-                .map(post -> PostConverter.toPostList(post, isPostLikedByUser(user, post)))
+                .map(post -> PostConverter.toPostList(
+                        post,
+                        isPostLikedByUser(user, post),
+                        post.getUser().getUserId().equals(user.getUserId())
+                ))
                 .collect(Collectors.toList());
 
         List<GetPostResponse> bestPostList = bestPosts.stream()
-                .map(post -> PostConverter.toPostList(post, isPostLikedByUser(user, post)))
+                .map(post -> PostConverter.toPostList(
+                        post,
+                        isPostLikedByUser(user, post),
+                        post.getUser().getUserId().equals(user.getUserId())
+                ))
                 .collect(Collectors.toList());
 
         return PostConverter.toPostListResponse(postList, bestPostList);
@@ -132,12 +140,12 @@ public class PostServiceImpl implements PostService {
         List<GetComment> commentDTOs = comments.stream()
                 .map(com -> PostConverter.toComment(
                         com,
-                        commentLikeRepository.existsByUserAndComment(user, com),
+                        com.getUser().getUserId().equals(user.getUserId()),
                         (int) commentLikeRepository.countByComment(com)
                 ))
                 .collect(Collectors.toList());
 
-        return PostConverter.toPostDetail(post, isPostLikedByUser(user, post), commentDTOs);
+        return PostConverter.toPostDetail(post, isPostLikedByUser(user, post), commentDTOs, post.getUser().getUserId().equals(user.getUserId()));
     }
 
     @Override
@@ -148,9 +156,12 @@ public class PostServiceImpl implements PostService {
 
         // 각 게시글에 대해 현재 사용자가 좋아요 눌렀는지 확인
         List<GetPostResponse> result = posts.stream()
-                .map(post -> PostConverter.toPostList(post, isPostLikedByUser(user, post)))
+                .map(post -> PostConverter.toPostList(
+                        post,
+                        isPostLikedByUser(user, post),
+                        post.getUser().getUserId().equals(user.getUserId())
+                ))
                 .collect(Collectors.toList());
-
         return PostConverter.toPostSearchResponse(result);
     }
 }

--- a/src/main/java/dorm/lounge/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/dorm/lounge/domain/post/service/PostServiceImpl.java
@@ -9,6 +9,7 @@ import dorm.lounge.domain.post.dto.PostDTO.PostRequest.CreatePostRequest;
 import dorm.lounge.domain.post.dto.PostDTO.PostResponse.GetPostResponse;
 import dorm.lounge.domain.post.entity.Comment;
 import dorm.lounge.domain.post.entity.Post;
+import dorm.lounge.domain.post.repository.CommentLikeRepository;
 import dorm.lounge.domain.post.repository.CommentRepository;
 import dorm.lounge.domain.post.repository.PostLikeRepository;
 import dorm.lounge.domain.post.repository.PostRepository;
@@ -30,6 +31,7 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
     private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
 
     @Override
     @Transactional
@@ -128,7 +130,11 @@ public class PostServiceImpl implements PostService {
         // 댓글 리스트 조회
         List<Comment> comments = commentRepository.findByPost(post);
         List<GetComment> commentDTOs = comments.stream()
-                .map(PostConverter::toComment)
+                .map(com -> PostConverter.toComment(
+                        com,
+                        commentLikeRepository.existsByUserAndComment(user, com),
+                        (int) commentLikeRepository.countByComment(com)
+                ))
                 .collect(Collectors.toList());
 
         return PostConverter.toPostDetail(post, isPostLikedByUser(user, post), commentDTOs);

--- a/src/main/java/dorm/lounge/domain/user/entity/User.java
+++ b/src/main/java/dorm/lounge/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package dorm.lounge.domain.user.entity;
 
+import dorm.lounge.domain.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -34,6 +37,9 @@ public class User {
 
     @Column(length = 500)
     private String refreshToken;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Post> posts = new ArrayList<>();
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;


### PR DESCRIPTION
## Related Issue 🍀
- #21 

<br>

## Key Changes 🔑
- 댓글 등록, 댓글 삭제 API 구현
- 게시글 상세 조회 시 comments 리스트에 isMine, likeCount 포함
- isMine : 현재 로그인한 사용자가 작성한 댓글인지 여부
- likeCount : 댓글 좋아요 수
- @OneToMany(mappedBy = "...", cascade = CascadeType.REMOVE) 설정 추가
- 사용자 탈퇴 시 관련 데이터가 전부 삭제되도록 설정

<br>

## To Reviewers 🙏🏻
- 